### PR TITLE
mark-devkit: Bump dev-lang/ruby-3.1.5-r1

### DIFF
--- a/dev-lang/ruby/ruby-3.1.5-r1.ebuild
+++ b/dev-lang/ruby/ruby-3.1.5-r1.ebuild
@@ -73,7 +73,7 @@ PDEPEND="
 
 
 src_prepare() {
-	sed -i -e "s|Gem.default_dir|ENV['GEM_DESTDIR']|g" tool/rbinstall.rb || die
+	eapply "${REPODIR}/dev-lang"/files/"${SLOT}"/010-default-gem-location.patch
 
 	einfo "Unbundling gems..."
 	cd "$S"


### PR DESCRIPTION
Automatic bump of package dev-lang/ruby-3.1.5-r1 for branch mark-xl by mark-bot