### PR TITLE
mark-devkit: Bump dev-lang/ruby-3.1.5-r1

### DIFF
--- a/dev-lang/ruby/ruby-3.1.5-r1.ebuild
+++ b/dev-lang/ruby/ruby-3.1.5-r1.ebuild
@@ -73,7 +73,7 @@ PDEPEND="
 
 
 src_prepare() {
-	eapply "${REPODIR}/dev-lang"/files/"${SLOT}"/010-default-gem-location.patch
+	sed -i -e "s|Gem.default_dir|ENV['GEM_DESTDIR']|g" tool/rbinstall.rb || die
 
 	einfo "Unbundling gems..."
 	cd "$S"
@@ -250,3 +250,5 @@ pkg_postinst() {
 pkg_postrm() {
 	eselect ruby cleanup
 }
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package dev-lang/ruby-3.1.5-r1 for branch mark-iii by mark-bot